### PR TITLE
fix: 修改vue依赖方式为peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "serve": "vite preview"
   },
   "packageManager": "^pnpm@7.0.0",
-  "dependencies": {
-    "vue": "^3.4.30"
+  "peerDependencies": {
+    "vue": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.8",


### PR DESCRIPTION
如果本地已经存在旧的vue版本，安装插件后会更新自带版本，更换依赖方式解决